### PR TITLE
Changes to GROUPR for two new meshes

### DIFF
--- a/src/groupr.f90
+++ b/src/groupr.f90
@@ -251,6 +251,8 @@ contains
    !     32           ukaea 1102-group structure   (1 GeV)
    !     33           ukaea  142-group structure (200 MeV)
    !     34           lanl 618-group structure
+   !     35           apollo 99-group structure
+   !     36           ecco 1962-group structure
    !
    !     igg          meaning
    !     ---          -------
@@ -1635,6 +1637,8 @@ contains
    !    32      UKAEA 1102-group structure
    !    33      UKAEA  142-group structure
    !    34      LANL 618 group structure
+   !    35      APOLLO 99-group structure
+   !    36      ECCO 1962-group structure
    !
    !-------------------------------------------------------------------
    use mainio ! provides nsyso
@@ -2673,8 +2677,8 @@ contains
      6.772865E+02_kr,7.485173E+02_kr,8.322179E+02_kr,9.096813E+02_kr,&
      9.824941E+02_kr,1.064323E+03_kr,1.134667E+03_kr,1.343582E+03_kr,&
      1.586197E+03_kr,1.811833E+03_kr,2.084104E+03_kr,2.397290E+03_kr,&
-     2.700236E+03_kr,2.996183E+03_kr,3.481068E+03_kr,4.097345E+03_kr,&
-     5.004508E+03_kr,6.112520E+03_kr,7.465848E+03_kr,9.118808E+03_kr,&
+     2.700236E+03_kr,2.996183E+03_kr,3.481068E+03_kr,3.936685E+03_kr,&
+     4.856602E+03_kr,5.991484E+03_kr,7.391562E+03_kr,9.118808E+03_kr,&
      1.113774E+04_kr,1.360366E+04_kr,1.489967E+04_kr,1.620045E+04_kr,&
      1.858471E+04_kr,2.269941E+04_kr,2.499908E+04_kr,2.610010E+04_kr,&
      2.739441E+04_kr,2.928101E+04_kr,3.345961E+04_kr,3.697859E+04_kr,&
@@ -2765,8 +2769,8 @@ contains
      8.322179E+02_kr,9.096813E+02_kr,9.824941E+02_kr,1.064323E+03_kr,&
      1.134667E+03_kr,1.343582E+03_kr,1.586197E+03_kr,1.811833E+03_kr,&
      2.084104E+03_kr,2.397290E+03_kr,2.700236E+03_kr,2.996183E+03_kr,&
-     3.481068E+03_kr,4.097345E+03_kr,5.004508E+03_kr,6.112520E+03_kr,&
-     7.465848E+03_kr,9.118808E+03_kr,1.113774E+04_kr,1.360366E+04_kr,&
+     3.481068E+03_kr,3.936685E+03_kr,4.856602E+03_kr,5.991484E+03_kr,&
+     7.391562E+03_kr,9.118808E+03_kr,1.113774E+04_kr,1.360366E+04_kr,&
      1.489967E+04_kr,1.620045E+04_kr,1.858471E+04_kr,2.269941E+04_kr,&
      2.499908E+04_kr,2.610010E+04_kr,2.739441E+04_kr,2.928101E+04_kr,&
      3.345961E+04_kr,3.697859E+04_kr,4.086766E+04_kr,4.991587E+04_kr,&
@@ -2843,8 +2847,8 @@ contains
      1.343584E+03_kr,1.586199E+03_kr,1.811835E+03_kr,2.034684E+03_kr,&
      2.284941E+03_kr,2.423809E+03_kr,2.571117E+03_kr,2.768596E+03_kr,&
      2.951579E+03_kr,3.146656E+03_kr,3.354626E+03_kr,3.707435E+03_kr,&
-     4.097350E+03_kr,4.528272E+03_kr,5.004514E+03_kr,5.530844E+03_kr,&
-     6.112528E+03_kr,6.755388E+03_kr,7.465858E+03_kr,8.251049E+03_kr,&
+     3.936685E+03_kr,4.372518E+03_kr,4.856602E+03_kr,5.394280E+03_kr,&
+     5.991484E+03_kr,6.654805E+03_kr,7.391562E+03_kr,8.209886E+03_kr,&
      9.118820E+03_kr,1.007785E+04_kr,1.113775E+04_kr,1.360368E+04_kr,&
      1.503439E+04_kr,1.620047E+04_kr,1.858473E+04_kr,2.269944E+04_kr,&
      2.478752E+04_kr,2.610013E+04_kr,2.739445E+04_kr,2.928104E+04_kr,&
@@ -4100,6 +4104,32 @@ contains
      1.92500000000000e+07_kr,1.93750000000000e+07_kr,1.95000000000000e+07_kr,&
      1.96250000000000e+07_kr,1.97500000000000e+07_kr,1.98750000000000e+07_kr,&
      2.00000000000000e+07_kr/)
+   real(kr),parameter::eg35(100)=(/&
+     1.100000E-04_kr,3.000000E-03_kr,5.500000E-03_kr,1.000000E-02_kr,&
+     1.500000E-02_kr,2.000000E-02_kr,3.000000E-02_kr,4.300000E-02_kr,&
+     5.900000E-02_kr,7.700000E-02_kr,9.500000E-02_kr,1.150000E-01_kr,&
+     1.340000E-01_kr,1.600000E-01_kr,1.890000E-01_kr,2.200000E-01_kr,&
+     2.480000E-01_kr,2.825000E-01_kr,3.145000E-01_kr,3.520000E-01_kr,&
+     3.910000E-01_kr,4.330000E-01_kr,4.850000E-01_kr,5.400000E-01_kr,&
+     6.250000E-01_kr,7.050000E-01_kr,7.900000E-01_kr,8.600000E-01_kr,&
+     9.300000E-01_kr,9.860001E-01_kr,1.035000E+00_kr,1.070000E+00_kr,&
+     1.110000E+00_kr,1.170000E+00_kr,1.235000E+00_kr,1.305000E+00_kr,&
+     1.370000E+00_kr,1.440000E+00_kr,1.510000E+00_kr,1.590000E+00_kr,&
+     1.670000E+00_kr,1.755000E+00_kr,1.840000E+00_kr,1.930000E+00_kr,&
+     2.020000E+00_kr,2.130000E+00_kr,2.360000E+00_kr,2.767920E+00_kr,&
+     3.380745E+00_kr,4.129250E+00_kr,5.043477E+00_kr,6.160121E+00_kr,&
+     7.523987E+00_kr,9.189817E+00_kr,1.122447E+01_kr,1.370959E+01_kr,&
+     1.674495E+01_kr,2.045232E+01_kr,2.498051E+01_kr,3.051126E+01_kr,&
+     3.726653E+01_kr,4.551748E+01_kr,5.559517E+01_kr,6.790408E+01_kr,&
+     9.166093E+01_kr,1.367420E+02_kr,2.039952E+02_kr,3.043250E+02_kr,&
+     4.539993E+02_kr,6.772877E+02_kr,1.010394E+03_kr,1.507332E+03_kr,&
+     2.248674E+03_kr,3.354626E+03_kr,5.004517E+03_kr,7.465859E+03_kr,&
+     1.113776E+04_kr,1.661558E+04_kr,2.478752E+04_kr,3.697866E+04_kr,&
+     5.516566E+04_kr,8.229753E+04_kr,1.227735E+05_kr,1.831564E+05_kr,&
+     2.732374E+05_kr,4.076221E+05_kr,6.081011E+05_kr,9.071799E+05_kr,&
+     1.108032E+06_kr,1.353353E+06_kr,1.652990E+06_kr,2.018966E+06_kr,&
+     2.465971E+06_kr,3.011943E+06_kr,3.678794E+06_kr,4.493290E+06_kr,&
+     5.488117E+06_kr,6.703201E+06_kr,8.187308E+06_kr,1.000000E+07_kr/)
    real(kr),parameter::ezero=1.e7_kr
    real(kr),parameter::tenth=0.10e0_kr
    real(kr),parameter::eighth=0.125e0_kr
@@ -4499,6 +4529,30 @@ contains
          egn(ig)=eg618(ig)
       enddo
 
+   !--apollo 99-group structure
+   else if (ign.eq.35) then
+      ngn=99
+      ngp=ngn+1
+      allocate(egn(ngp))
+      do ig=1,ngp
+         egn(ig)=eg35(ig)
+      enddo
+
+   !--ecco 1962-group structure
+   else if (ign.eq.36) then
+      ngn=1962
+      ngp=ngn+1
+      allocate(egn(ngp))
+      do ig=1,392
+         egn(ig)=eg20a(ig)
+      enddo
+      do ig=1,392
+         egn(ig+392)=eg20b(ig)
+      enddo
+      do ig=785,ngp
+         egn(ig)=egn(ig-1)*exp(1.0d0/120.0d0)
+      enddo
+
    !--illegal ign
    else
       call error('gengpn','illegal group structure.',' ')
@@ -4579,6 +4633,12 @@ contains
      &  '' neutron group structure......ukaea 1102-group'')')
    if (ign.eq.33) write(nsyso,'(/&
      &  '' neutron group structure......ukaea 142-group'')')
+   if (ign.eq.34) write(nsyso,'(/&
+     &  '' neutron group structure......lanl 618-group'')')
+   if (ign.eq.35) write(nsyso,'(/&
+     &  '' neutron group structure......apollo 99-group'')')
+   if (ign.eq.36) write(nsyso,'(/&
+     &  '' neutron group structure......ecco  1962-group'')')
    if (ign.ne.-1) then
       do ig=1,ngn
          write(nsyso,'(1x,i5,2x,1p,e12.5,''  - '',e12.5)')&
@@ -11805,7 +11865,7 @@ contains
    ethi=0
    if (ed.eq.zero) then
       ier=1
-      ntmp=250000
+      ntmp=300000
       do while (ier.ne.0)
          if (allocated(tmp)) deallocate(tmp)
          allocate(tmp(ntmp),stat=ier)


### PR DESCRIPTION
I'm working with Alain Hébert (developer of the DRAGON code) on integrating a (probably standalone) _dragr_ module in NJOY.  The goal is to have an optionally compiled module that can be built along-side stock NJOY.  He has made some other changes to the NJOY code itself that we are trying to avoid, but there are some _groupr_ changes that he wishes to try to get in to NJOY.

They basically update some energy grids that Alain had been able to add to NJOY a few years ago to try address a resonance self-shielding issue.  They also add two new energy grids.

I don't know how receptive you are to the addition of these grids.  I am open to alternatives.  Again, the goal on our side is to create a module that links to `libnjoy.so` and can be used as a final step in a processing chain.  

* Some changes to meshes 25, 26, and 27 to address resonance self-shielding issues,
* Addition of meshes 35 and 36 (EDF/Framatome and Newcleo),
* Addition of descriptive print statements, including one missed for mesh 34,
* Increase size of ntmp to accomodate ECCO1962 mesh.